### PR TITLE
ignore anything other then ExpressionStatement

### DIFF
--- a/src/no-async-in-foreach.js
+++ b/src/no-async-in-foreach.js
@@ -40,6 +40,10 @@ module.exports = {
           node,
           message: 'An async callback inside `forEach` swallows promises. You should either convert to `for...of` syntax, or swap `forEach` for `map` and wrap in a `Promise.all`.',
           fix(fixer) {
+            if (node.parent.type !== 'ExpressionStatement' && node.parent.type !== 'ChainExpression') {
+              return;
+            }
+
             let element = functionExpression.params[0];
             let rightAssignment;
 

--- a/test/no-async-in-foreach-test.js
+++ b/test/no-async-in-foreach-test.js
@@ -152,6 +152,17 @@ new RuleTester({
         }
       ],
       output: 'async()=>{for (let bar of foo?.bar ?? []) {await bar}}'
+    },
+
+    // nested
+    {
+      code: 'async()=>{return foo.forEach(async(bar)=>await bar)}',
+      errors: [
+        {
+          message: 'An async callback inside `forEach` swallows promises. You should either convert to `for...of` syntax, or swap `forEach` for `map` and wrap in a `Promise.all`.',
+          type: 'CallExpression'
+        }
+      ]
     }
   ]
 });


### PR DESCRIPTION
This excludes return, yield, or inside another CallExpression.